### PR TITLE
Fix build on arm64 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
 set(EXTRA_CMAKE_FLAGS)
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64|aarch64|armhf")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*|arm.*|ARM.*)")
   # Flags for non SIMD architectures
   # https://github.com/gazebo-forks/ogre-2.3-release/blob/960bb19664879282b979e4ed8cb3ce278c875bdb/debian/rules#L21-L28
   set(EXTRA_CMAKE_FLAGS -DOGRE_SIMD_NEON:BOOL=FALSE  -DOGRE_SIMD_SSE2:BOOL=FALSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ find_package(ament_cmake_vendor_package REQUIRED)
 
 set(EXTRA_CMAKE_FLAGS)
 message("Detected arch ${CMAKE_SYSTEM_PROCESSOR}")
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64|aarch64|armhf")
+  message("Disabling SIMD_NEON and SIMD_SSE2")
   # Flags for non SIMD architectures
   # https://github.com/gazebo-forks/ogre-2.3-release/blob/960bb19664879282b979e4ed8cb3ce278c875bdb/debian/rules#L21-L28
   set(EXTRA_CMAKE_FLAGS -DOGRE_SIMD_NEON:BOOL=FALSE  -DOGRE_SIMD_SSE2:BOOL=FALSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
 set(EXTRA_CMAKE_FLAGS)
+message("Detected arch ${CMAKE_SYSTEM_PROCESSOR}")
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
   # Flags for non SIMD architectures
   # https://github.com/gazebo-forks/ogre-2.3-release/blob/960bb19664879282b979e4ed8cb3ce278c875bdb/debian/rules#L21-L28

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,13 @@ project(gz_ogre_next_vendor)
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
+set(EXTRA_CMAKE_FLAGS)
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+  # Flags for non SIMD architectures
+  # https://github.com/gazebo-forks/ogre-2.3-release/blob/960bb19664879282b979e4ed8cb3ce278c875bdb/debian/rules#L21-L28
+  set(EXTRA_CMAKE_FLAGS -DOGRE_SIMD_NEON:BOOL=FALSE  -DOGRE_SIMD_SSE2:BOOL=FALSE)
+endif()
+
 ament_vendor(${PROJECT_NAME}
   VCS_URL https://github.com/OGRECave/ogre-next.git
   VCS_VERSION v2.3.3
@@ -24,6 +31,7 @@ ament_vendor(${PROJECT_NAME}
     -DOGRE_USE_NEW_PROJECT_NAME:BOOL=ON
     -DOGRE_VULKAN_WINDOW_NULL:BOOL=TRUE
     -DOGRE_VULKAN_WINDOW_XCB:BOOL=ON
+    ${EXTRA_CMAKE_FLAGS}
   GLOBAL_HOOK
   PATCHES
     patches/0001-Fix-incomplete-vulkan-linkage.patch

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,7 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
 set(EXTRA_CMAKE_FLAGS)
-message("Detected arch ${CMAKE_SYSTEM_PROCESSOR}")
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64|aarch64|armhf")
-  message("Disabling SIMD_NEON and SIMD_SSE2")
   # Flags for non SIMD architectures
   # https://github.com/gazebo-forks/ogre-2.3-release/blob/960bb19664879282b979e4ed8cb3ce278c875bdb/debian/rules#L21-L28
   set(EXTRA_CMAKE_FLAGS -DOGRE_SIMD_NEON:BOOL=FALSE  -DOGRE_SIMD_SSE2:BOOL=FALSE)


### PR DESCRIPTION
Ogre currently needs `SIMD_NEON` `SIMD_SSE2` turned off in order to build on arm64 architecture. These are also used in our upstream Ogre-next packages:

- https://github.com/gazebo-forks/ogre-2.3-release/blob/960bb19664879282b979e4ed8cb3ce278c875bdb/debian/rules#L21-L28
- https://git.launchpad.net/ubuntu/+source/ogre-next/tree/debian/rules?h=ubuntu/noble-proposed#n8

I've tested this locally with docker (with qemu) and it built successfully.

Upstream issue: https://github.com/OGRECave/ogre-next/issues/430
