### PR TITLE
Add check for system installed ogre-next

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 
 ament_vendor(${PROJECT_NAME}
 SATISFIED ${OGRE2_FOUND}
-VCS_URL https://github.com/OGRECave/${GITHUB_NAME}.git
+VCS_URL https://github.com/OGRECave/ogre-next.git
   VCS_VERSION v${LIB_VER}
   CMAKE_ARGS
     -DOGRE_STATIC:BOOL=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,37 @@
 cmake_minimum_required(VERSION 3.10)
 project(gz_ogre_next_vendor)
 
+# Project-specific settings
+set(LIB_VER_MAJOR 2)
+set(LIB_VER_MINOR 3)
+set(LIB_VER_PATCH 3)
+
+# Derived variables
+set(LIB_VER ${LIB_VER_MAJOR}.${LIB_VER_MINOR}.${LIB_VER_PATCH})
+
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
-# Required for FindGzOGRE2.cmake and gz_find_package 
-# find_package(gz_cmake_vendor REQUIRED)
+# Required for FindGzOGRE2.cmake and gz_find_package
+find_package(gz_cmake_vendor REQUIRED)
 find_package(gz-cmake3 REQUIRED)
 
+# Set the VERSION_MATCH to "EXACT" by default, but relax the requirement
+# if we are users are building from source (determined by the
+# GZ_BUILD_FROM_SOURCE environment variable) or if explicitly told to do so
+# by the GZ_RELAX_VERSION_MATCH environment variable.
+set(VERSION_MATCH "EXACT")
+if(NOT $ENV{GZ_BUILD_FROM_SOURCE} STREQUAL "")
+  set(VERSION_MATCH "")
+endif()
+
+if(NOT $ENV{GZ_RELAX_VERSION_MATCH} STREQUAL "")
+  set(VERSION_MATCH "")
+endif()
+
 gz_find_package(GzOGRE2
-  VERSION 2.3.1
+  EXACT ${VERSION_MATCH}
+  VERSION ${LIB_VER}
   COMPONENTS
   HlmsPbs
   HlmsUnlit
@@ -28,8 +50,8 @@ endif()
 
 ament_vendor(${PROJECT_NAME}
 SATISFIED ${OGRE2_FOUND}
-VCS_URL https://github.com/OGRECave/ogre-next.git
-  VCS_VERSION v2.3.3
+VCS_URL https://github.com/OGRECave/${GITHUB_NAME}.git
+  VCS_VERSION v${LIB_VER}
   CMAKE_ARGS
     -DOGRE_STATIC:BOOL=OFF
     -DOGRE_BUILD_COMPONENT_OVERLAY:BOOL=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,21 @@ project(gz_ogre_next_vendor)
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
+# Required for FindGzOGRE2.cmake and gz_find_package 
+# find_package(gz_cmake_vendor REQUIRED)
+find_package(gz-cmake3 REQUIRED)
+
+gz_find_package(GzOGRE2
+  VERSION 2.3.1
+  COMPONENTS
+  HlmsPbs
+  HlmsUnlit
+  Overlay
+  PlanarReflections
+  PRIVATE_FOR ogre2
+  QUIET
+)
+
 set(EXTRA_CMAKE_FLAGS)
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*|arm.*|ARM.*)")
   # Flags for non SIMD architectures
@@ -12,7 +27,8 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*|arm.*|A
 endif()
 
 ament_vendor(${PROJECT_NAME}
-  VCS_URL https://github.com/OGRECave/ogre-next.git
+SATISFIED ${OGRE2_FOUND}
+VCS_URL https://github.com/OGRECave/ogre-next.git
   VCS_VERSION v2.3.3
   CMAKE_ARGS
     -DOGRE_STATIC:BOOL=OFF
@@ -36,6 +52,11 @@ ament_vendor(${PROJECT_NAME}
   PATCHES
     patches/0001-Fix-incomplete-vulkan-linkage.patch
 )
+
+message("OGRE2_FOUND: ${OGRE2_FOUND}")
+message("OGRE2_VERSION: ${OGRE2_VERSION}")
+message("OGRE2_INCLUDE_DIRS: ${OGRE2_INCLUDE_DIRS}")
+message("OGRE2_LIBRARIES: ${OGRE2_LIBRARIES}")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
+  <buildtool_depend>gz_cmake_vendor</buildtool_depend>
 
   <depend>glslang-dev</depend>
   <depend>glslc</depend>


### PR DESCRIPTION
- Add support for system ogre installation
- Add exact/inexact version matching like the other vendor libs. Note that FindGzOGRE2.cmake is relaxed in its version matching, so it might pick another version. 

Resolves #4