### PR TITLE
Fix use of gz-cmake vendor package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(ament_cmake_vendor_package REQUIRED)
 
 # Required for FindGzOGRE2.cmake and gz_find_package
 find_package(gz_cmake_vendor REQUIRED)
-find_package(gz-cmake3 REQUIRED)
+find_package(gz-cmake REQUIRED)
 
 # Set the VERSION_MATCH to "EXACT" by default, but relax the requirement
 # if we are users are building from source (determined by the

--- a/package.xml
+++ b/package.xml
@@ -28,8 +28,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
-  <buildtool_depend>gz_cmake_vendor</buildtool_depend>
 
+  <depend>gz_cmake_vendor</depend>
   <depend>glslang-dev</depend>
   <depend>glslc</depend>
   <depend>libboost-date-time-dev</depend>


### PR DESCRIPTION
This ensures that this works with gz-cmake4 as well

Needs https://github.com/gazebo-release/gz_cmake_vendor/pull/8