### PR TITLE
Rolling: missing atomic depends. 0.2.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
     To avoid any confusion with the version of the vendor package, the major
     version here will always be 0.
   -->
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>
     Vendor package for Ogre-next v2.3.3
   </description>
@@ -32,6 +32,7 @@
   <depend>gz_cmake_vendor</depend>
   <depend>glslang-dev</depend>
   <depend>glslc</depend>
+  <depend>libatomic</depend>
   <depend>libboost-date-time-dev</depend>
   <depend>libboost-dev</depend>
   <depend>libboost-thread-dev</depend>


### PR DESCRIPTION
Failing build https://build.ros2.org/job/Kbin_rhel_el964__gz_ogre_next_vendor__rhel_9_x86_64__binary/215/