### PR TITLE
Mark gz_cmake_vendor as a build dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
     To avoid any confusion with the version of the vendor package, the major
     version here will always be 0.
   -->
-  <version>0.1.0</version>
+  <version>0.3.0</version>
   <description>
     Vendor package for Ogre-next v2.3.3
   </description>

--- a/package.xml
+++ b/package.xml
@@ -29,7 +29,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
 
-  <depend>gz_cmake_vendor</depend>
+  <build_depend>gz_cmake_vendor</build_depend>
+
   <depend>glslang-dev</depend>
   <depend>glslc</depend>
   <depend>libboost-date-time-dev</depend>

--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
     To avoid any confusion with the version of the vendor package, the major
     version here will always be 0.
   -->
-  <version>0.3.0</version>
+  <version>0.2.0</version>
   <description>
     Vendor package for Ogre-next v2.3.3
   </description>


### PR DESCRIPTION
I don't remember exactly what issue I was having, but I had it in my todo list to make gz_cmake_vendor a build dependency for a while. Now that we are likely to make a release with #9, I wanted to take the opportunity to fix this.