### PR TITLE
Fix ogre-next build failure on Xcode 26 (xcodebuild -n removed)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ VCS_URL https://github.com/OGRECave/ogre-next.git
   GLOBAL_HOOK
   PATCHES
     patches/0001-Fix-incomplete-vulkan-linkage.patch
-    patches/0002-cxx20-constexpr-stlallocator.patch
+    patches/0002-fix-xcodebuild-n-xcode26.patch
 )
 
 message("OGRE2_FOUND: ${OGRE2_FOUND}")

--- a/patches/0002-fix-xcodebuild-n-xcode26.patch
+++ b/patches/0002-fix-xcodebuild-n-xcode26.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -360,10 +360,10 @@ elseif (APPLE AND NOT OGRE_BUILD_PLATFORM_APPLE_IOS)
+
+   set(XCODE_ATTRIBUTE_SDKROOT macosx)
+   if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+-    execute_process(COMMAND xcodebuild -version -sdk "${XCODE_ATTRIBUTE_SDKROOT}" Path | head -n 1 OUTPUT_VARIABLE CMAKE_OSX_SYSROOT)
++    execute_process(COMMAND xcrun --sdk macosx --show-sdk-path OUTPUT_VARIABLE CMAKE_OSX_SYSROOT)
+     string(REGEX REPLACE "(\r?\n)+$" "" CMAKE_OSX_SYSROOT "${CMAKE_OSX_SYSROOT}")
+   else()
+     set(CMAKE_OSX_SYSROOT macosx)
+   endif()
+
+   set( CMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES )


### PR DESCRIPTION
## Problem

Xcode 26 removed the `-n` flag from `xcodebuild`. ogre-next v2.3.3's CMakeLists.txt uses `execute_process` with a shell pipe to detect the macOS SDK path:

```cmake
execute_process(
  COMMAND xcodebuild -version -sdk "${XCODE_ATTRIBUTE_SDKROOT}" Path | head -n 1
  OUTPUT_VARIABLE CMAKE_OSX_SYSROOT)
```

CMake's `execute_process` does not use a shell, so `| head -n 1` is passed as literal arguments to `xcodebuild`. With Xcode 26, the `-n` argument is rejected:

```
xcodebuild: error: option '-n' is no longer supported
Usage: xcodebuild [-project <projectname>] [[-target <targetname>]...|-alltargets] [-configuration <configurationname>] ...
       xcodebuild [-project <projectname>] -scheme <schemeName> [-destination <destinationspecifier>]...
       ...
```

The full usage page is captured into `CMAKE_OSX_SYSROOT`, corrupting it with embedded newlines and breaking all subsequent compiler invocations:

```
/bin/sh: -c: line 0: unexpected EOF while looking for matching `"'
/bin/sh: -c: line 1: syntax error: unexpected end of file
```

## Fix

Add `patches/0002-fix-xcodebuild-n-xcode26.patch` which replaces the broken call with:

```cmake
execute_process(COMMAND xcrun --sdk macosx --show-sdk-path
                OUTPUT_VARIABLE CMAKE_OSX_SYSROOT)
```

`xcrun --show-sdk-path` is the correct modern replacement and works across all supported Xcode versions.

Fyi, @traversaro.